### PR TITLE
✏ Fix typo in leaderboards url

### DIFF
--- a/Leaderboards/README.md
+++ b/Leaderboards/README.md
@@ -1,6 +1,6 @@
 # Leaderboards API
 
-Running frontend application: https://leaderboads.skylords.eu
+Running frontend application: https://leaderboards.skylords.eu
 
 Running backend application: https://leaderboards.backend.skylords.eu
 


### PR DESCRIPTION
I thought the deployment is offline the first time I clicked that link 😱.